### PR TITLE
[STYLE] 버튼 상위 폴더 지정 및 검색 바 다른 페이지로 분리

### DIFF
--- a/src/assets/css/train.css
+++ b/src/assets/css/train.css
@@ -76,6 +76,10 @@
     margin-left: 10px;
 }
 
+.search-box ::placeholder {
+    font-size: 15px;
+}
+
 .search-btn {
     height: 35px;
     cursor: pointer;

--- a/src/pages/public/SearchBar.jsx
+++ b/src/pages/public/SearchBar.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+function SearchBar() {
+  return (
+    <div className="search-group">
+      <select className="filter-select">
+        <option value="latest">최신순</option>
+        <option value="popular">인기순</option>
+      </select>
+
+      <div className="search-box">
+        <input type="text" placeholder="검색어를 입력하세요" />
+        <div className="search-btn">
+          <img src="src/assets/img/reading-glasses.svg" alt="돋보기" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SearchBar;

--- a/src/pages/public/Train.jsx
+++ b/src/pages/public/Train.jsx
@@ -2,11 +2,11 @@ import "../../assets/css/train.css";
 import paw from "../../assets/img/paw.svg";
 import { useNavigate } from "react-router-dom";
 import trainData from "../../pages/owner/trainData.json";
+import TrainCard from "../owner/TrainCard";
+import SearchBar from "./SearchBar";
 
 function Train() {
   const navigate = useNavigate();
-
-  const trainingData = trainData;
 
   const handleCardClick = (id) => {
     navigate(`/train/${id}`);
@@ -23,39 +23,17 @@ function Train() {
           />
           <div className="training-title">전체훈련 목록</div>
         </div>
-
-        <div className="search-group">
-          <select className="filter-select">
-            <option value="latest">최신순</option>
-            <option value="popular">인기순</option>
-          </select>
-
-          <div className="search-box">
-            <input type="text" placeholder="검색어를 입력하세요" />
-            <div className="search-btn">
-              <img src="src/assets/img/reading-glasses.svg" alt="돋보기" />
-            </div>
-          </div>
-        </div>
+        <SearchBar />
       </div>
 
       <div className="train-list">
         {/* map 함수를 사용하여 카드 자동 생성 */}
-        {trainingData.map((item) => (
-          <div
+        {trainData.map((item) => (
+          <TrainCard
             key={item.trainId}
-            className="train-card"
+            item={item}
             onClick={() => handleCardClick(item.trainId)}
-          >
-            <div className="tr-card-img">
-              {item.trainImg && (
-                <img src={item.trainImg} alt={item.trainTitle} />
-              )}
-            </div>
-            <div className="tr-card-content">
-              <span className="tr-card-title">{item.trainTitle}</span>
-            </div>
-          </div>
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## 📌 관련 이슈
- close #37

## 📁 작업 유형
- [ ] 새로운 기능 추가 [FEATURE]
- [ ] 기존 기능 수정 [MODIFY] 
- [ ] 오류 수정 [FIX]
- [ ] 파일 혹은 폴더명 수정 [RENAME]
- [x] 자잘한 코드 수정 [STYLE]

## ✨ 작업 내용
- 적용되는 버튼 css 이름 변경
- 검색 바 다른 페이지로 분리 및 수정

## 🧩 변경 이유
-  같은 css를 사용하기에 같은 이름 버튼은 다 같은 css 적용됨
- 그래서 상위 폴더랑 같이 지정해서 해당 버튼만 변경되도록 수정
- 검색 바 다른 곳에서도 사용하기 위해 다른 파일로 분리함

## 🔍 기타
- 

## 📸 스크린샷
> UI 변경이 있다면 첨부해주세요.
