### PR TITLE
[FEATURE] 훈련 전체 목록에서 훈련 내용 카드 파일 분리 #39 #8

### DIFF
--- a/src/assets/css/searchBar.css
+++ b/src/assets/css/searchBar.css
@@ -1,0 +1,55 @@
+.search-group {
+    display: flex;
+    gap: 10px;           /*필터와 검색창 사이 간격*/
+    margin-right: 30px;
+    align-items: center;
+}
+
+.filter-select {
+    height: 35px;
+    padding: 5px 15px;
+    border-radius: 10px;
+    border: 1px solid #D7E1E8;
+    color: #6B5949;
+    cursor: pointer;
+    outline: none;
+    background-color: transparent;
+}
+
+.filter-select option {
+    background-color: transparent;
+}
+
+.search-box {
+    height: 35px;
+    display: flex;
+    align-items: center;
+    border: 1px solid #D7E1E8;
+    border-radius: 10px;
+    margin: 0px;
+    padding: 0px;
+}
+
+.search-box input {
+    width: 100%;
+    border: none;
+    outline: none;
+    background-color: transparent;
+    margin-left: 10px;
+}
+
+.search-box ::placeholder {
+    font-size: 15px;
+}
+
+.search-btn {
+    height: 35px;
+    cursor: pointer;
+    background-color: #D7E1E8;
+    padding: 10px;
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    display: flex;
+    overflow: hidden;
+    justify-content: center;
+}

--- a/src/assets/css/train.css
+++ b/src/assets/css/train.css
@@ -36,62 +36,6 @@
     margin-left: 10px;
 }
 
-.search-group {
-    display: flex;
-    gap: 10px;           /*필터와 검색창 사이 간격*/
-    margin-right: 30px;
-    align-items: center;
-}
-
-.filter-select {
-    height: 35px;
-    padding: 5px 15px;
-    border-radius: 10px;
-    border: 1px solid #D7E1E8;
-    color: #6B5949;
-    cursor: pointer;
-    outline: none;
-    background-color: transparent;
-}
-
-.filter-select option {
-    background-color: transparent;
-}
-
-.search-box {
-    height: 35px;
-    display: flex;
-    align-items: center;
-    border: 1px solid #D7E1E8;
-    border-radius: 10px;
-    margin: 0px;
-    padding: 0px;
-}
-
-.search-box input {
-    width: 100%;
-    border: none;
-    outline: none;
-    background-color: transparent;
-    margin-left: 10px;
-}
-
-.search-box ::placeholder {
-    font-size: 15px;
-}
-
-.search-btn {
-    height: 35px;
-    cursor: pointer;
-    background-color: #D7E1E8;
-    padding: 10px;
-    border-top-right-radius: 10px;
-    border-bottom-right-radius: 10px;
-    display: flex;
-    overflow: hidden;
-    justify-content: center;
-}
-
 .train-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, 300px);

--- a/src/assets/css/trainDetaile.css
+++ b/src/assets/css/trainDetaile.css
@@ -141,13 +141,23 @@ hr {
     gap: 5px;
 }
 
-.btn1 {
-    padding: 10px 30px;
-    margin-top: auto;
-    font-size: 18px;
+.review-box .btn1, .notice-box .btn1 {
+    height: 40px;
+    font-size: 15px;
 }
 
-.btn3 {
+.btn-group {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.btn-group button {
+  width: 100%;
+}
+
+.btn1 .pay, .btn3 {
     font-size: 18px;
 }
 

--- a/src/pages/owner/TrainCard.jsx
+++ b/src/pages/owner/TrainCard.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+function TrainCard({ item, onClick }) {
+  return (
+    <div className="train-card" onClick={() => onClick(item.trainID)}>
+      <div className="tr-card-img">
+        {item.trainImg && <img src={item.trainImg} alt={item.trainTitle} />}
+      </div>
+
+      <div className="tr-card-content">
+        <span className="tr-card-title">{item.trainTitle}</span>
+      </div>
+    </div>
+  );
+}
+
+export default TrainCard;

--- a/src/pages/public/Train.jsx
+++ b/src/pages/public/Train.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import trainData from "../../pages/owner/trainData.json";
 import TrainCard from "../owner/TrainCard";
 import SearchBar from "./SearchBar";
+import "../../assets/css/searchBar.css";
 
 function Train() {
   const navigate = useNavigate();

--- a/src/pages/public/TrainDetaile.jsx
+++ b/src/pages/public/TrainDetaile.jsx
@@ -73,8 +73,10 @@ function TrainDetaile() {
           <span>{detail.price.toLocaleString()}원</span>
         </div>
 
-        <button className="btn1">결제하기</button>
-        <button className="btn3">장바구니 담기</button>
+        <div className="btn-group">
+          <button className="btn1 pay">결제하기</button>
+          <button className="btn3">장바구니 담기</button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 관련 이슈
- close #39  #8 

## 📁 작업 유형
- [x] 새로운 기능 추가 [FEATURE]
- [ ] 기존 기능 수정 [MODIFY] 
- [ ] 오류 수정 [FIX]
- [ ] 파일 혹은 폴더명 수정 [RENAME]
- [ ] 자잘한 코드 수정 [STYLE]

## ✨ 작업 내용
- 훈련 전체 목록에서 훈련 내용 카드 다른 파일로 분리
- css 파일 분리
- 훈련 전체 페이지와 상세 페이지 css 제작 완료

## 🧩 변경 이유
- 

## 🔍 기타
- 

## 📸 스크린샷
<img width="2848" height="1532" alt="image" src="https://github.com/user-attachments/assets/20089213-5e42-4215-bc35-6cf7eb795164" />
